### PR TITLE
Make payment method check more resilient

### DIFF
--- a/app/views/spree/checkout/payment/_affirm.html.erb
+++ b/app/views/spree/checkout/payment/_affirm.html.erb
@@ -149,13 +149,19 @@
             handle continue button clicks with .open()
         \*****************************************************/
         $('#checkout_form_payment').submit(function(e){
-          var checkedPaymentMethod = $('div[data-hook="checkout_payment_step"] input[type="radio"]:checked').val();
+          var selectedPaymentMethod = $('input[name="order[payments_attributes][][payment_method_id]"]');
+          var type = selectedPaymentMethod.attr("type");
+          if (type && type.toLowerCase() == 'radio') {
+            selectedPaymentMethod = selectedPaymentMethod.filter(":checked").val();
+          } else {
+            selectedPaymentMethod = selectedPaymentMethod.val();
+          }
 
-          if (window.AffirmPaymentMethods[checkedPaymentMethod]) {
+          if (window.AffirmPaymentMethods[selectedPaymentMethod]) {
             var $submit_button = $(this).find("input[type='submit']");
 
             // update with checkout method details
-            affirm.checkout(window.AffirmPaymentMethods[checkedPaymentMethod]);
+            affirm.checkout(window.AffirmPaymentMethods[selectedPaymentMethod]);
 
             // show the loading message
             $submit_button.trigger("loading");


### PR DESCRIPTION
In the JavaScript, it's better for us to rely on the name of the input to determine if the customer has chosen Affirm. Picking the first checked radio button will cause some issues with [the wallet code](https://github.com/solidusio/solidus/blob/master/frontend/app/views/spree/checkout/_payment.html.erb#L6) as well as anywhere that chooses a different method of recording the payment method ID.