### PR TITLE
Make Affirm checkouts non-reusable

### DIFF
--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -11,6 +11,10 @@ module Spree
       "Affirm Checkout"
     end
 
+    def reusable?
+      false
+    end
+
     def details
       @details ||= payment_method.provider.get_checkout token
     end


### PR DESCRIPTION
This commit into core:
https://github.com/solidusio/solidus/commit/547d459c26b2f48bbe2a75b58c90063f678fced2

Added a check if payment sources are `#reusable?`. The
`SolidusAffirm::Checkout` model here is used as the payment source, but
doesn't implement that method, causing any code that looks up reusable
sources to throw a method missing error.

One example where I've seen this error is the /admin/payments/new page.